### PR TITLE
fix: remove duplicate state updates in scheduler (fixes #57)

### DIFF
--- a/src/scheduler/engine.rs
+++ b/src/scheduler/engine.rs
@@ -126,8 +126,6 @@ impl SchedulerHandle {
             .await
             .map_err(|_| SchedulerError::ChannelError("failed to receive pause response".into()))?;
 
-        let mut state = self.state.write().await;
-        *state = SchedulerState::Paused;
         Ok(())
     }
 
@@ -145,8 +143,6 @@ impl SchedulerHandle {
             .await
             .map_err(|_| SchedulerError::ChannelError("failed to receive resume response".into()))?;
 
-        let mut state = self.state.write().await;
-        *state = SchedulerState::Running;
         Ok(())
     }
 
@@ -166,8 +162,6 @@ impl SchedulerHandle {
                 SchedulerError::ChannelError("failed to receive shutdown response".into())
             })?;
 
-        let mut state = self.state.write().await;
-        *state = SchedulerState::Stopped;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
Fixes #57 - Critical race condition in scheduler state management

## Problem
The scheduler state was being updated in **two places**:
1. In the scheduler loop when processing pause/resume/shutdown commands
2. In the handle methods after receiving command responses

This created a race condition where state could become inconsistent between the two update points.

## Solution
Removed duplicate state updates from the handle methods (`pause()`, `resume()`, `shutdown()`). The scheduler loop is now the single source of truth for state management.

## Changes
- Removed state update from `SchedulerHandle::pause()`
- Removed state update from `SchedulerHandle::resume()`  
- Removed state update from `SchedulerHandle::shutdown()`

State is now only updated in the scheduler loop's command processing block, ensuring consistent and predictable state transitions.

## Testing
- All existing scheduler tests pass
- No behavior changes from user perspective
- State management is now deterministic

🤖 Generated with [Claude Code](https://claude.com/claude-code)