### PR TITLE
fix: handle semaphore closure gracefully in TaskExecutor

### DIFF
--- a/src/execution/dag_executor.rs
+++ b/src/execution/dag_executor.rs
@@ -190,7 +190,15 @@ impl DagExecutor {
 
                     // Execute (uses semaphore for concurrency control)
                     let task_start = Instant::now();
-                    let result = executor.execute(task.as_ref(), &mut task_ctx).await;
+                    let result = match executor.execute(task.as_ref(), &mut task_ctx).await {
+                        Ok(result) => result,
+                        Err(e) => TaskResult::failure(
+                            task_id.clone(),
+                            0,
+                            task_start.elapsed(),
+                            e.to_string(),
+                        ),
+                    };
                     let task_duration = task_start.elapsed();
 
                     // Merge outputs back to shared store

--- a/tests/yaml_api_sketch.rs
+++ b/tests/yaml_api_sketch.rs
@@ -635,7 +635,7 @@ async fn test_task_executor_directly() {
         .build();
 
     let mut ctx = create_test_context();
-    let result = executor.execute(&task, &mut ctx).await;
+    let result = executor.execute(&task, &mut ctx).await.unwrap();
 
     assert!(result.success);
     assert_eq!(result.attempts, 1);


### PR DESCRIPTION
## Summary

- Change `TaskExecutor::execute()` return type from `TaskResult` to `Result<TaskResult, TaskError>`
- Replace `.expect("semaphore closed")` with graceful error handling via `.map_err()`
- Add `close()` and `is_closed()` methods for graceful shutdown support
- Update `dag_executor.rs` to handle the new Result type
- Add test for semaphore closed scenario

## Test plan

- [x] All existing tests pass (288 tests)
- [x] New test `test_execute_returns_error_when_semaphore_closed` verifies the fix
- [x] Clippy passes with no new warnings

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)