### PR TITLE
feat: add Makefile and CI workflow for Rust linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: make fmt-check
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Run clippy
+        run: make lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run tests
+        run: make test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Petit - Task Orchestrator
+
+A minimal, lightweight task orchestrator with cron-like scheduling written in Rust.
+
+## Project Structure
+
+```
+src/
+├── config/      # YAML configuration loading and job builders
+├── core/        # Core types: Job, Task, DAG, Schedule, Retry policies
+├── events/      # Event bus for task/job lifecycle events
+├── execution/   # Task executors and DAG execution engine
+├── scheduler/   # Cron-based scheduler engine
+├── storage/     # Storage backends (in-memory, SQLite)
+├── testing/     # Test harness and mock utilities
+├── lib.rs       # Public API exports
+└── main.rs      # CLI entry point
+```
+
+## Development Commands
+
+Use the Makefile for all development tasks:
+
+```bash
+make fmt        # Format code with rustfmt
+make fmt-check  # Check formatting without modifying
+make lint       # Run clippy with warnings as errors
+make test       # Run all tests
+make check      # Quick compile check
+make build      # Build release binary
+make ci         # Run all CI checks (fmt-check, lint, test)
+make all        # Same as ci
+```
+
+## Code Style
+
+- Run `make fmt` before committing
+- All clippy warnings are treated as errors (`-D warnings`)
+- Use `--all-features` when running checks to include SQLite feature
+
+## CI/CD
+
+GitHub Actions runs on every push and PR to main:
+- **Format check**: Verifies code is formatted with rustfmt
+- **Lint**: Runs clippy with all features enabled
+- **Test**: Runs the full test suite
+
+## Features
+
+- `sqlite` - Enables SQLite storage backend (optional)
+
+## Testing
+
+Tests are co-located with source files. The `testing` module provides:
+- `TestHarness` for integration tests
+- `MockTaskContext` for unit tests
+- `ExecutionTracker` for verifying task execution order

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: all check fmt fmt-check lint test build clean
+
+# Run all checks (formatting, linting, tests)
+all: fmt-check lint test
+
+# Quick compile check without producing binaries
+check:
+	cargo check --all-features
+
+# Format code
+fmt:
+	cargo fmt
+
+# Check formatting without modifying files
+fmt-check:
+	cargo fmt -- --check
+
+# Run clippy linter with warnings as errors
+lint:
+	cargo clippy --all-features --all-targets -- -D warnings
+
+# Run tests
+test:
+	cargo test --all-features
+
+# Build release binary
+build:
+	cargo build --release
+
+# Clean build artifacts
+clean:
+	cargo clean
+
+# Run CI checks (same as GitHub Actions)
+ci: fmt-check lint test


### PR DESCRIPTION
## Summary
- Add Makefile with standard Rust development targets (`fmt`, `fmt-check`, `lint`, `test`, `build`, `ci`)
- Add GitHub Actions CI workflow that runs format check, clippy lint, and tests on push/PR to main
- Add CLAUDE.md documenting project structure and development commands

## Test plan
- [ ] Verify Makefile targets work locally (`make fmt-check`, `make lint`, `make test`)
- [ ] Verify CI workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)