### PR TITLE
fix: remove unused Timeline/ExecutionTracker types from testing module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,7 @@ pub use config::{
 };
 
 pub use scheduler::{Scheduler, SchedulerError, SchedulerHandle, SchedulerState};
-pub use testing::{
-    ExecutionTracker, FailingTask, FailureInjection, MockTaskContext, TestHarness, TestResult,
-    Timeline, TimelineEntry, TimelineEventType, TrackedTask,
-};
+pub use testing::{FailingTask, FailureInjection, MockTaskContext, TestHarness, TestResult};
 
 #[cfg(feature = "api")]
 pub use api::{ApiConfig, ApiState, build_router, create_api_state, start_server};


### PR DESCRIPTION
## Summary
Remove unused timeline tracking types from the testing module that were defined but not effectively integrated.

## Removed Types
- `ExecutionTracker` - shared tracker for recording task execution
- `Timeline` - wrapper for timeline verification
- `TimelineEntry` - individual timeline events
- `TimelineEventType` - event type enum (Started, Completed, Failed, Retrying)
- `TrackedTask<T>` - task wrapper for recording to tracker

## Changes to TestHarness
- Removed `tracker` field
- Removed `with_tracker()` method
- Removed `tracker()` method  
- Removed `timeline()` method
- Updated documentation to remove timeline references

## Rationale
These types required manual task wrapping with `TrackedTask` and weren't integrated into `TestHarness::execute()`. The tracking never happened automatically, making the API misleading. Rather than implementing proper integration, this PR removes the unused code.

## Test plan
- [x] All existing tests pass (5 timeline tests removed)
- [x] CI checks pass (fmt, lint, test)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)