### PR TITLE
docs: document API feature flag requirement for CLI flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,15 +56,20 @@ make all        # Same as ci
 ### CLI (pt binary)
 
 ```bash
-# Run scheduler with jobs from a directory
-cargo run -- run --jobs ./jobs
+# Run scheduler with jobs from a directory (API server starts by default)
+cargo run -- run ./jobs
 
-# Run scheduler with API server
-cargo run -- run --jobs ./jobs --api
+# Run scheduler without API server (requires api feature, enabled by default)
+cargo run -- run ./jobs --no-api
+
+# Run scheduler with custom API settings
+cargo run -- run ./jobs --api-port 8080 --api-host 0.0.0.0
 
 # Trigger a specific job once and exit
-cargo run -- run --jobs ./jobs --trigger my_job
+cargo run -- trigger ./jobs my_job
 ```
+
+**Note:** The `--no-api`, `--api-port`, and `--api-host` flags require the `api` feature to be enabled (which is the default). If compiling with `--no-default-features`, these flags will not be available.
 
 ### TUI Dashboard
 
@@ -104,9 +109,19 @@ GitHub Actions runs on every push and PR to main:
 
 ## Features
 
-- `sqlite` - Enables SQLite storage backend
+- `api` - Enables HTTP REST API and related CLI flags (`--no-api`, `--api-port`, `--api-host`). **Enabled by default.**
+- `sqlite` - Enables SQLite storage backend and `--db` CLI flag
 - `tui` - Enables terminal UI dashboard (includes sqlite)
-- `api` - Enables HTTP REST API (default)
+
+### Building Without Default Features
+
+```bash
+# Build without API support (no API server or API-related CLI flags)
+cargo build --no-default-features
+
+# Build with only SQLite support (no API)
+cargo build --no-default-features --features sqlite
+```
 
 ## Testing
 
@@ -123,7 +138,7 @@ Integration tests in `tests/integration/` cover:
 
 ## API Endpoints
 
-When running with `--api`, the following endpoints are available:
+When the `api` feature is enabled (default), an HTTP REST API server starts automatically unless `--no-api` is specified. The following endpoints are available:
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|

--- a/README.md
+++ b/README.md
@@ -28,19 +28,30 @@ No! I built this to see what it would take to build an orchestrator with Claude 
 - **Conditional execution** — Run tasks based on upstream success/failure
 - **Cross-job dependencies** — Jobs can depend on other jobs
 - **Event system** — Subscribe to lifecycle events (task started, completed, failed, etc.)
+- **HTTP REST API** — Optional API server for monitoring and control (enabled by default)
 - **Pluggable storage** — In-memory (default) or SQLite for persistence
 - **Concurrency control** — Limit parallel tasks and concurrent job runs
+
+### Feature Flags
+
+- `api` — Enables HTTP REST API and related CLI flags (`--no-api`, `--api-port`, `--api-host`). **Enabled by default.**
+- `sqlite` — Enables SQLite storage backend and `--db` CLI flag
+- `tui` — Enables terminal UI dashboard (includes sqlite)
 
 ## Installation
 
 ```bash
+# Default installation (includes API feature)
 cargo install --path .
 
 # With SQLite support
 cargo install --path . --features sqlite
 
 # With TUI support
-cargo install --path . --features tui,sqlite
+cargo install --path . --features tui
+
+# Minimal installation (no API, no SQLite)
+cargo install --path . --no-default-features
 ```
 
 ## Quick Start
@@ -92,11 +103,17 @@ pt trigger <jobs-dir> <job-id>  # Trigger a job manually
 
 ### Options for `run`
 
-| Flag                  | Description                                     |
-| --------------------- | ----------------------------------------------- |
-| `-j, --max-jobs <N>`  | Maximum concurrent jobs (default: unlimited)    |
-| `-t, --max-tasks <N>` | Maximum concurrent tasks per job (default: 4)   |
-| `--tick-interval <N>` | Scheduler tick interval in seconds (default: 1) |
+| Flag                  | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `-j, --max-jobs <N>`  | Maximum concurrent jobs (default: unlimited)                          |
+| `-t, --max-tasks <N>` | Maximum concurrent tasks per job (default: 4)                         |
+| `--tick-interval <N>` | Scheduler tick interval in seconds (default: 1)                       |
+| `--db <PATH>`         | Path to SQLite database file (requires `sqlite` feature)              |
+| `--no-api`            | Disable HTTP API server (requires `api` feature, enabled by default)  |
+| `--api-port <PORT>`   | API server port (default: 8565, requires `api` feature)               |
+| `--api-host <HOST>`   | API server host (default: 127.0.0.1, requires `api` feature)          |
+
+**Note:** API-related flags (`--no-api`, `--api-port`, `--api-host`) are only available when the `api` feature is enabled (which is the default). If you compile with `--no-default-features`, these flags will not be available and no API server will start.
 
 ## Job Configuration
 


### PR DESCRIPTION
## Summary

Adds clear documentation that API-related CLI flags require the `api` feature to be enabled (which is the default).

This addresses issue #90 by clarifying that:
- The `api` feature is enabled by default
- CLI flags `--no-api`, `--api-port`, and `--api-host` require the `api` feature
- Users compiling with `--no-default-features` won't have these flags available
- The API server starts automatically unless `--no-api` is specified

## Changes

### CLAUDE.md
- Updated CLI examples to show API is enabled by default
- Added note about feature requirements for API flags
- Reorganized Features section to list `api` first with emphasis on it being default
- Added "Building Without Default Features" section with examples
- Updated API Endpoints section to clarify automatic startup behavior

### README.md
- Added "Feature Flags" subsection under Features
- Updated CLI options table to include all flags with feature requirements
- Added note about API flag availability
- Updated installation examples to include `--no-default-features` option

## Test plan

- [x] Run `make ci` - all checks pass
- [x] Verify documentation is clear and accurate
- [x] Confirm changes address the issue raised in #90

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)