### PR TITLE
Config: Add more helpful error messages with context

### DIFF
--- a/src/core/job.rs
+++ b/src/core/job.rs
@@ -556,7 +556,8 @@ mod tests {
             .with_dependency(JobDependency::new(job_id.clone()));
 
         // Even if the job is in known_jobs, self-dependency should be rejected
-        let result = job.validate(&[job_id]);
+        let known_jobs: HashSet<JobId> = [job_id].into_iter().collect();
+        let result = job.validate(&known_jobs);
         assert!(matches!(result, Err(JobError::InvalidDependency(_))));
 
         if let Err(JobError::InvalidDependency(msg)) = result {


### PR DESCRIPTION
## Summary

Improves error messages in the config module to include contextual information like job names, task names, file paths, and available options. This makes it much easier to identify and fix configuration issues, especially in large config files.

## Changes

- **File paths in errors**: All file loading errors now include the file path being loaded
- **Job context**: Validation and build errors include the job name for easy identification
- **Task context**: Task-specific errors include both job and task names
- **Available tasks**: Dependency errors now show the list of available tasks
- **Directory context**: Directory loading errors include the directory path
- **YAML error wrapping**: YAML parse errors now include file context

## Examples

### Before
```
task 'transform' depends on unknown task 'extractt'
```

### After
```
Job 'ETL Pipeline': Task 'transform' depends on unknown task 'extractt'. Available tasks: ["extract", "load"]
```

### Before
```
failed to read file: No such file or directory (os error 2)
```

### After
```
failed to read file '/path/to/jobs/missing.yaml': No such file or directory (os error 2)
```

## Test plan

- [x] All existing tests pass (make ci)
- [x] Error messages now include contextual information as expected
- [x] Validation logic remains unchanged, only error message formatting improved

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)