### PR TITLE
feat: Add configuration file support for CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
 dependencies = [
  "chrono",
  "once_cell",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -506,6 +506,27 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1259,6 +1280,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1346,7 @@ dependencies = [
  "clap",
  "cron",
  "crossterm",
+ "dirs",
  "http-body-util",
  "ratatui",
  "serde",
@@ -1329,6 +1357,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
+ "toml",
  "tower",
  "tower-http",
  "tracing",
@@ -1505,6 +1534,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1677,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2183,6 +2232,47 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2796,6 +2886,15 @@ name = "winnow"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ chrono-tz = "0.10"
 clap = { version = "4", features = ["derive", "env"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+toml = "0.8"
+dirs = "6"
 ratatui = { version = "0.29", optional = true }
 crossterm = { version = "0.28", optional = true }
 axum = { version = "0.8", optional = true }

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,0 +1,91 @@
+# Petit Configuration File Example
+#
+# This file demonstrates all available configuration options for the Petit task orchestrator.
+# By default, Petit looks for this file at ~/.config/petit/config.toml
+# You can also specify a custom config path using: pt --config /path/to/config.toml
+#
+# Command-line arguments always take precedence over configuration file settings.
+
+# Storage Configuration
+# Defines how Petit stores job runs, task states, and execution history.
+[storage]
+# Storage engine: "memory" or "sqlite"
+# - memory: Fast, but data is lost when the application stops
+# - sqlite: Persistent storage to a database file (requires sqlite feature)
+engine = "memory"
+
+# For SQLite storage, specify the database file path:
+# engine = "sqlite"
+# path = "/var/lib/petit/petit.db"
+
+# API Server Configuration (requires api feature, enabled by default)
+[api]
+# Enable or disable the HTTP REST API server
+enabled = true
+
+# Host address to bind the API server
+host = "127.0.0.1"
+
+# Port number for the API server
+port = 8565
+
+# Scheduler Configuration
+[scheduler]
+# Maximum number of concurrent jobs (default: unlimited)
+# Uncomment to limit concurrent job execution:
+# max_jobs = 10
+
+# Maximum number of concurrent tasks per job (default: 4)
+max_tasks = 4
+
+# Scheduler tick interval in seconds (default: 1)
+# How often the scheduler checks for jobs that need to run
+tick_interval = 1
+
+# Example configurations for different use cases:
+
+# === Development Configuration ===
+# Use in-memory storage for quick testing without persistence
+# [storage]
+# engine = "memory"
+#
+# [api]
+# enabled = true
+# host = "127.0.0.1"
+# port = 8565
+#
+# [scheduler]
+# max_tasks = 2
+# tick_interval = 1
+
+# === Production Configuration ===
+# Use SQLite for persistent storage and reasonable concurrency limits
+# [storage]
+# engine = "sqlite"
+# path = "/var/lib/petit/petit.db"
+#
+# [api]
+# enabled = true
+# host = "0.0.0.0"
+# port = 8565
+#
+# [scheduler]
+# max_jobs = 50
+# max_tasks = 8
+# tick_interval = 1
+
+# === High-Throughput Configuration ===
+# Maximize concurrency for high-volume task processing
+# [storage]
+# engine = "sqlite"
+# path = "/var/lib/petit/petit.db"
+#
+# [api]
+# enabled = true
+# host = "0.0.0.0"
+# port = 8565
+#
+# [scheduler]
+# max_jobs = 100
+# max_tasks = 16
+# tick_interval = 1

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -1,0 +1,253 @@
+//! CLI configuration file support.
+//!
+//! This module provides support for loading configuration from TOML files.
+//! Configuration can be loaded from:
+//! 1. An explicit path specified via --config flag
+//! 2. The XDG config directory (~/.config/petit/config.toml)
+//! 3. Fall back to defaults
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("Failed to read config file: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Failed to parse TOML config: {0}")]
+    TomlError(#[from] toml::de::Error),
+}
+
+/// Storage configuration options.
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(tag = "engine", rename_all = "lowercase")]
+pub enum StorageConfig {
+    /// In-memory storage (default).
+    #[default]
+    Memory,
+    /// SQLite storage with a database file path.
+    #[cfg(feature = "sqlite")]
+    Sqlite { path: PathBuf },
+}
+
+/// API server configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ApiConfig {
+    /// Enable the API server (default: true).
+    #[serde(default = "default_api_enabled")]
+    pub enabled: bool,
+
+    /// API server host (default: 127.0.0.1).
+    #[serde(default = "default_api_host")]
+    pub host: String,
+
+    /// API server port (default: 8565).
+    #[serde(default = "default_api_port")]
+    pub port: u16,
+}
+
+fn default_api_enabled() -> bool {
+    true
+}
+
+fn default_api_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_api_port() -> u16 {
+    8565
+}
+
+impl Default for ApiConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_api_enabled(),
+            host: default_api_host(),
+            port: default_api_port(),
+        }
+    }
+}
+
+/// Scheduler configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SchedulerConfig {
+    /// Maximum concurrent jobs (default: unlimited).
+    #[serde(default)]
+    pub max_jobs: Option<usize>,
+
+    /// Maximum concurrent tasks per job (default: 4).
+    #[serde(default = "default_max_tasks")]
+    pub max_tasks: usize,
+
+    /// Scheduler tick interval in seconds (default: 1).
+    #[serde(default = "default_tick_interval")]
+    pub tick_interval: u64,
+}
+
+fn default_max_tasks() -> usize {
+    4
+}
+
+fn default_tick_interval() -> u64 {
+    1
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            max_jobs: None,
+            max_tasks: default_max_tasks(),
+            tick_interval: default_tick_interval(),
+        }
+    }
+}
+
+/// Top-level configuration structure.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct Config {
+    /// Storage configuration.
+    #[serde(default)]
+    pub storage: StorageConfig,
+
+    /// API server configuration.
+    #[cfg(feature = "api")]
+    #[serde(default)]
+    pub api: ApiConfig,
+
+    /// Scheduler configuration.
+    #[serde(default)]
+    pub scheduler: SchedulerConfig,
+}
+
+impl Config {
+    /// Load configuration from a TOML file.
+    pub fn from_file(path: &PathBuf) -> Result<Self, ConfigError> {
+        let contents = std::fs::read_to_string(path)?;
+        let config: Config = toml::from_str(&contents)?;
+        Ok(config)
+    }
+
+    /// Get the default XDG config path (~/.config/petit/config.toml).
+    pub fn default_config_path() -> Option<PathBuf> {
+        dirs::config_dir().map(|mut path| {
+            path.push("petit");
+            path.push("config.toml");
+            path
+        })
+    }
+
+    /// Load configuration with priority:
+    /// 1. Explicit config path if provided
+    /// 2. XDG config path if it exists
+    /// 3. Default configuration
+    pub fn load(explicit_path: Option<PathBuf>) -> Result<Self, ConfigError> {
+        // Try explicit path first
+        if let Some(path) = explicit_path {
+            return Self::from_file(&path);
+        }
+
+        // Try XDG default path
+        if let Some(path) = Self::default_config_path()
+            && path.exists()
+        {
+            return Self::from_file(&path);
+        }
+
+        // Fall back to defaults
+        Ok(Self::default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::default();
+        assert!(matches!(config.storage, StorageConfig::Memory));
+        #[cfg(feature = "api")]
+        {
+            assert!(config.api.enabled);
+            assert_eq!(config.api.host, "127.0.0.1");
+            assert_eq!(config.api.port, 8565);
+        }
+        assert_eq!(config.scheduler.max_tasks, 4);
+        assert_eq!(config.scheduler.tick_interval, 1);
+    }
+
+    #[test]
+    fn test_parse_memory_storage() {
+        let toml = r#"
+[storage]
+engine = "memory"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(matches!(config.storage, StorageConfig::Memory));
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[test]
+    fn test_parse_sqlite_storage() {
+        let toml = r#"
+[storage]
+engine = "sqlite"
+path = "/tmp/test.db"
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        match config.storage {
+            StorageConfig::Sqlite { path } => {
+                assert_eq!(path, PathBuf::from("/tmp/test.db"));
+            }
+            _ => panic!("Expected SQLite storage"),
+        }
+    }
+
+    #[cfg(feature = "api")]
+    #[test]
+    fn test_parse_api_config() {
+        let toml = r#"
+[api]
+enabled = false
+host = "0.0.0.0"
+port = 9000
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(!config.api.enabled);
+        assert_eq!(config.api.host, "0.0.0.0");
+        assert_eq!(config.api.port, 9000);
+    }
+
+    #[test]
+    fn test_parse_scheduler_config() {
+        let toml = r#"
+[scheduler]
+max_jobs = 10
+max_tasks = 8
+tick_interval = 5
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.scheduler.max_jobs, Some(10));
+        assert_eq!(config.scheduler.max_tasks, 8);
+        assert_eq!(config.scheduler.tick_interval, 5);
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let toml = r#"
+[storage]
+engine = "memory"
+
+[scheduler]
+max_jobs = 5
+max_tasks = 2
+tick_interval = 10
+"#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert!(matches!(config.storage, StorageConfig::Memory));
+        assert_eq!(config.scheduler.max_jobs, Some(5));
+        assert_eq!(config.scheduler.max_tasks, 2);
+        assert_eq!(config.scheduler.tick_interval, 10);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,10 @@
 //!   pt validate <jobs-dir> Validate job configurations without running
 //!   pt list <jobs-dir>    List all jobs in the directory
 
+mod cli_config;
+
 use clap::{Parser, Subcommand};
+use cli_config::Config;
 use petit::{
     DagExecutor, EventBus, EventHandler, InMemoryStorage, Scheduler, Storage,
     load_jobs_from_directory,
@@ -26,6 +29,10 @@ use tracing::{error, info, warn};
 #[command(name = "pt")]
 #[command(author, version, about, long_about = None)]
 struct Cli {
+    /// Path to configuration file (overrides XDG default)
+    #[arg(short, long, global = true)]
+    config: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -38,19 +45,19 @@ enum Commands {
         #[arg(value_name = "JOBS_DIR")]
         jobs_dir: PathBuf,
 
-        /// Maximum concurrent jobs (default: unlimited)
+        /// Maximum concurrent jobs (overrides config file)
         #[arg(short = 'j', long)]
         max_jobs: Option<usize>,
 
-        /// Maximum concurrent tasks per job (default: 4)
-        #[arg(short = 't', long, default_value = "4")]
-        max_tasks: usize,
+        /// Maximum concurrent tasks per job (overrides config file, default: 4)
+        #[arg(short = 't', long)]
+        max_tasks: Option<usize>,
 
-        /// Scheduler tick interval in seconds (default: 1)
-        #[arg(long, default_value = "1")]
-        tick_interval: u64,
+        /// Scheduler tick interval in seconds (overrides config file, default: 1)
+        #[arg(long)]
+        tick_interval: Option<u64>,
 
-        /// Path to SQLite database file for persistent storage (requires sqlite feature)
+        /// Path to SQLite database file for persistent storage (overrides config file)
         #[cfg(feature = "sqlite")]
         #[arg(long, env = "PETIT_DB")]
         db: Option<PathBuf>,
@@ -60,15 +67,15 @@ enum Commands {
         #[arg(long)]
         no_api: bool,
 
-        /// API server port (default: 8565)
+        /// API server port (overrides config file, default: 8565)
         #[cfg(feature = "api")]
-        #[arg(long, default_value = "8565")]
-        api_port: u16,
+        #[arg(long)]
+        api_port: Option<u16>,
 
-        /// API server host (default: 127.0.0.1)
+        /// API server host (overrides config file, default: 127.0.0.1)
         #[cfg(feature = "api")]
-        #[arg(long, default_value = "127.0.0.1")]
-        api_host: String,
+        #[arg(long)]
+        api_host: Option<String>,
     },
 
     /// Validate job configurations without running
@@ -100,6 +107,60 @@ enum Commands {
         #[arg(long, env = "PETIT_DB")]
         db: Option<PathBuf>,
     },
+}
+
+/// Merge CLI arguments with file configuration (with API support).
+/// CLI arguments take priority over file configuration.
+#[cfg(feature = "api")]
+#[allow(clippy::too_many_arguments)]
+fn merge_config(
+    file_config: &Config,
+    cli_max_jobs: Option<usize>,
+    cli_max_tasks: Option<usize>,
+    cli_tick_interval: Option<u64>,
+    cli_db: Option<PathBuf>,
+    cli_no_api: bool,
+    cli_api_port: Option<u16>,
+    cli_api_host: Option<String>,
+) -> (
+    Option<usize>,     // max_jobs
+    usize,             // max_tasks
+    u64,               // tick_interval
+    Option<PathBuf>,   // db_path
+    Option<ApiConfig>, // api_config
+) {
+    // Merge max_jobs: CLI > config file > default (None)
+    let max_jobs = cli_max_jobs.or(file_config.scheduler.max_jobs);
+
+    // Merge max_tasks: CLI > config file > default
+    let max_tasks = cli_max_tasks.unwrap_or(file_config.scheduler.max_tasks);
+
+    // Merge tick_interval: CLI > config file > default
+    let tick_interval = cli_tick_interval.unwrap_or(file_config.scheduler.tick_interval);
+
+    // Merge storage configuration
+    let db_path = cli_db.or_else(|| {
+        #[cfg(feature = "sqlite")]
+        if let cli_config::StorageConfig::Sqlite { path } = &file_config.storage {
+            return Some(path.clone());
+        }
+        None
+    });
+
+    // Merge API configuration
+    let api_config = if cli_no_api {
+        None
+    } else {
+        let host = cli_api_host.unwrap_or_else(|| file_config.api.host.clone());
+        let port = cli_api_port.unwrap_or(file_config.api.port);
+        if file_config.api.enabled {
+            Some(ApiConfig::new(host, port))
+        } else {
+            None
+        }
+    };
+
+    (max_jobs, max_tasks, tick_interval, db_path, api_config)
 }
 
 /// Simple logging event handler that prints job events.
@@ -208,6 +269,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
+    // Load configuration from file (explicit or XDG default)
+    let file_config = match Config::load(cli.config.clone()) {
+        Ok(config) => {
+            if cli.config.is_some() {
+                info!(
+                    "Loaded configuration from: {}",
+                    cli.config.as_ref().unwrap().display()
+                );
+            } else if let Some(default_path) = Config::default_config_path()
+                && default_path.exists()
+            {
+                info!("Loaded configuration from: {}", default_path.display());
+            }
+            config
+        }
+        Err(e) => {
+            error!("Failed to load configuration: {}", e);
+            return Err(e.into());
+        }
+    };
+
     match cli.command {
         #[cfg(all(feature = "sqlite", feature = "api"))]
         Commands::Run {
@@ -220,12 +302,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             api_port,
             api_host,
         } => {
-            let api_config = if no_api {
-                None
-            } else {
-                Some(ApiConfig::new(api_host, api_port))
-            };
-            run_scheduler(jobs_dir, max_jobs, max_tasks, tick_interval, db, api_config).await?;
+            let (
+                merged_max_jobs,
+                merged_max_tasks,
+                merged_tick_interval,
+                merged_db,
+                merged_api_config,
+            ) = merge_config(
+                &file_config,
+                max_jobs,
+                max_tasks,
+                tick_interval,
+                db,
+                no_api,
+                api_port,
+                api_host,
+            );
+            run_scheduler(
+                jobs_dir,
+                merged_max_jobs,
+                merged_max_tasks,
+                merged_tick_interval,
+                merged_db,
+                merged_api_config,
+            )
+            .await?;
         }
         #[cfg(all(feature = "sqlite", not(feature = "api")))]
         Commands::Run {
@@ -235,7 +336,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tick_interval,
             db,
         } => {
-            run_scheduler(jobs_dir, max_jobs, max_tasks, tick_interval, db, ()).await?;
+            let (merged_max_jobs, merged_max_tasks, merged_tick_interval, merged_db) = {
+                let config_max_jobs = max_jobs.or(file_config.scheduler.max_jobs);
+                let config_max_tasks = max_tasks.unwrap_or(file_config.scheduler.max_tasks);
+                let config_tick_interval =
+                    tick_interval.unwrap_or(file_config.scheduler.tick_interval);
+                let config_db = db.or_else(|| {
+                    if let cli_config::StorageConfig::Sqlite { path } = &file_config.storage {
+                        Some(path.clone())
+                    } else {
+                        None
+                    }
+                });
+                (
+                    config_max_jobs,
+                    config_max_tasks,
+                    config_tick_interval,
+                    config_db,
+                )
+            };
+            run_scheduler(
+                jobs_dir,
+                merged_max_jobs,
+                merged_max_tasks,
+                merged_tick_interval,
+                merged_db,
+                (),
+            )
+            .await?;
         }
         #[cfg(all(not(feature = "sqlite"), feature = "api"))]
         Commands::Run {
@@ -247,18 +375,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             api_port,
             api_host,
         } => {
-            let api_config = if no_api {
-                None
-            } else {
-                Some(ApiConfig::new(api_host, api_port))
-            };
+            let (merged_max_jobs, merged_max_tasks, merged_tick_interval, _, merged_api_config) =
+                merge_config(
+                    &file_config,
+                    max_jobs,
+                    max_tasks,
+                    tick_interval,
+                    None,
+                    no_api,
+                    api_port,
+                    api_host,
+                );
             run_scheduler(
                 jobs_dir,
-                max_jobs,
-                max_tasks,
-                tick_interval,
+                merged_max_jobs,
+                merged_max_tasks,
+                merged_tick_interval,
                 None::<PathBuf>,
-                api_config,
+                merged_api_config,
             )
             .await?;
         }
@@ -269,11 +403,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             max_tasks,
             tick_interval,
         } => {
+            let (merged_max_jobs, merged_max_tasks, merged_tick_interval, _) = {
+                let config_max_jobs = max_jobs.or(file_config.scheduler.max_jobs);
+                let config_max_tasks = max_tasks.unwrap_or(file_config.scheduler.max_tasks);
+                let config_tick_interval =
+                    tick_interval.unwrap_or(file_config.scheduler.tick_interval);
+                (
+                    config_max_jobs,
+                    config_max_tasks,
+                    config_tick_interval,
+                    None::<PathBuf>,
+                )
+            };
             run_scheduler(
                 jobs_dir,
-                max_jobs,
-                max_tasks,
-                tick_interval,
+                merged_max_jobs,
+                merged_max_tasks,
+                merged_tick_interval,
                 None::<PathBuf>,
                 (),
             )


### PR DESCRIPTION
## Summary

This PR implements configuration file support for the CLI, allowing users to specify settings in a TOML file instead of command-line arguments. This addresses issue #78.

## Changes

### Core Implementation
- **Config Module (`src/cli_config.rs`)**: New module that handles TOML parsing and configuration loading with priority handling
- **CLI Updates (`src/main.rs`)**: Added `--config` global flag and modified Run command to merge CLI args with file config
- **Dependencies**: Added `toml` (v0.8) and `dirs` (v6) crates

### Configuration Priority
The configuration is loaded with the following priority:
1. Command-line arguments (highest priority)
2. Explicit config file via `--config` flag
3. XDG default path (`~/.config/petit/config.toml`)
4. Built-in defaults (lowest priority)

### Configuration Options
Users can now configure:
- **Storage**: Engine type (`memory` or `sqlite`) and database path
- **API Server**: Enable/disable, host, and port settings
- **Scheduler**: Max concurrent jobs, max tasks per job, and tick interval

### Example
```toml
[storage]
engine = "sqlite"
path = "/var/lib/petit/petit.db"

[api]
enabled = true
host = "0.0.0.0"
port = 8565

[scheduler]
max_jobs = 50
max_tasks = 8
tick_interval = 1
```

## Files Added
- `src/cli_config.rs` - Configuration module with TOML parsing
- `examples/config.toml` - Comprehensive example config with comments

## Files Modified
- `Cargo.toml` - Added toml and dirs dependencies
- `src/main.rs` - Added config loading and CLI arg merging
- `Cargo.lock` - Lock file updates

## Testing
- All existing tests pass
- Added 6 new unit tests for config parsing
- Tested config priority handling with merge_config function

## Documentation
- Added extensive comments in example config file
- Documented all config options with examples
- Updated CLI help text to indicate config overrides

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>