### PR TITLE
fix: add Node.js files to .gitignore to prevent accidental commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.db-*
 /target
 .claude/
+
+# Prevent accidental Node.js files (this is a Rust project)
+package.json
+package-lock.json
+node_modules/


### PR DESCRIPTION
## Summary

- Add `package.json`, `package-lock.json`, and `node_modules/` to `.gitignore`
- These Node.js files were accidentally committed in PR #35 and have since been removed
- This change prevents them from being accidentally added again in the future

## Context

The files `package.json` and `package-lock.json` were accidentally committed to the repository root in the phase-11-job-definition branch. While they have since been removed (in commit a5d249de), they could be accidentally re-added. 

This PR adds these files to `.gitignore` to ensure they stay out of the repository, as this is a Rust project and Node.js files serve no purpose here.

## Test plan

- [x] Run `make ci` to verify all checks pass
- [x] Verify `.gitignore` includes the new entries
- [x] Confirm no package.json files exist in the repository

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)