### PR TITLE
fix: reject self-dependencies in Job::validate()

### DIFF
--- a/src/core/job.rs
+++ b/src/core/job.rs
@@ -20,6 +20,10 @@ pub enum JobError {
     #[error("invalid DAG: {0}")]
     InvalidDag(String),
 
+    /// Invalid dependency.
+    #[error("invalid dependency: {0}")]
+    InvalidDependency(String),
+
     /// Missing dependency.
     #[error("missing job dependency: {0}")]
     MissingDependency(String),
@@ -227,6 +231,7 @@ impl Job {
     ///
     /// Checks that:
     /// - The DAG is valid
+    /// - No self-dependencies exist
     /// - All dependency job IDs are provided in known_jobs
     pub fn validate(&self, known_jobs: &[JobId]) -> Result<(), JobError> {
         // Validate DAG
@@ -234,8 +239,16 @@ impl Job {
             .validate()
             .map_err(|e| JobError::InvalidDag(e.to_string()))?;
 
-        // Validate dependencies exist
+        // Validate dependencies
         for dep in &self.dependencies {
+            // Check for self-dependency
+            if dep.job_id == self.id {
+                return Err(JobError::InvalidDependency(
+                    "job cannot depend on itself".to_string(),
+                ));
+            }
+
+            // Check dependency exists
             if !known_jobs.contains(&dep.job_id) {
                 return Err(JobError::MissingDependency(dep.job_id.to_string()));
             }
@@ -510,6 +523,22 @@ mod tests {
 
         let result = job.validate(&[JobId::new("upstream"), JobId::new("other")]);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_job_rejects_self_dependency() {
+        let dag = create_simple_dag();
+        let job_id = JobId::new("self_dep_job");
+        let job = Job::new(job_id.clone(), "Self Dependent Job", dag)
+            .with_dependency(JobDependency::new(job_id.clone()));
+
+        // Even if the job is in known_jobs, self-dependency should be rejected
+        let result = job.validate(&[job_id]);
+        assert!(matches!(result, Err(JobError::InvalidDependency(_))));
+
+        if let Err(JobError::InvalidDependency(msg)) = result {
+            assert!(msg.contains("cannot depend on itself"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `InvalidDependency` error variant to `JobError` enum
- Update `Job::validate()` to reject self-dependencies before checking if dependencies exist in known_jobs
- Add comprehensive test case to verify self-dependencies are properly rejected

## Problem

`Job::validate()` didn't reject self-dependencies. A job that depends on itself would validate successfully as soon as the job ID is in `known_jobs`, but the dependency can never be satisfied since a job can't complete before it starts.

## Solution

Added validation logic that checks if any dependency's `job_id` equals the job's own `id` and returns an `InvalidDependency` error with the message "job cannot depend on itself".

The check is performed before validating that dependencies exist in `known_jobs`, ensuring self-dependencies are caught regardless of whether the job is in the known jobs list.

## Test Plan

- [x] Added test case `test_validate_job_rejects_self_dependency` that verifies:
  - Self-dependencies are rejected with `InvalidDependency` error
  - Error message contains "cannot depend on itself"
  - Rejection happens even when the job is in `known_jobs`
- [x] All existing tests pass (`make ci`)
- [x] Code formatted with rustfmt
- [x] Clippy checks pass with no warnings

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)