### PR TITLE
fix: use HashSet for O(1) job validation lookups

### DIFF
--- a/src/core/job.rs
+++ b/src/core/job.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -228,7 +228,7 @@ impl Job {
     /// Checks that:
     /// - The DAG is valid
     /// - All dependency job IDs are provided in known_jobs
-    pub fn validate(&self, known_jobs: &[JobId]) -> Result<(), JobError> {
+    pub fn validate(&self, known_jobs: &HashSet<JobId>) -> Result<(), JobError> {
         // Validate DAG
         self.dag
             .validate()
@@ -488,7 +488,8 @@ mod tests {
         let dag = create_etl_dag();
         let job = Job::new("valid_job", "Valid Job", dag);
 
-        let result = job.validate(&[]);
+        let known_jobs = HashSet::new();
+        let result = job.validate(&known_jobs);
         assert!(result.is_ok());
     }
 
@@ -498,7 +499,9 @@ mod tests {
         let job = Job::new("dep_job", "Dependent Job", dag)
             .with_dependency(JobDependency::new(JobId::new("nonexistent")));
 
-        let result = job.validate(&[JobId::new("other_job")]);
+        let mut known_jobs = HashSet::new();
+        known_jobs.insert(JobId::new("other_job"));
+        let result = job.validate(&known_jobs);
         assert!(matches!(result, Err(JobError::MissingDependency(_))));
     }
 
@@ -508,7 +511,10 @@ mod tests {
         let job = Job::new("dep_job", "Dependent Job", dag)
             .with_dependency(JobDependency::new(JobId::new("upstream")));
 
-        let result = job.validate(&[JobId::new("upstream"), JobId::new("other")]);
+        let mut known_jobs = HashSet::new();
+        known_jobs.insert(JobId::new("upstream"));
+        known_jobs.insert(JobId::new("other"));
+        let result = job.validate(&known_jobs);
         assert!(result.is_ok());
     }
 


### PR DESCRIPTION
## Summary

Changed `Job::validate()` to accept `&HashSet<JobId>` instead of `&[JobId]` for improved performance when validating cross-job dependencies.

## Changes

- Updated `Job::validate()` signature to use `&HashSet<JobId>` parameter
- Added `HashSet` import to `std::collections` in `src/core/job.rs`
- Updated all test cases to construct `HashSet` instances instead of using slice literals

## Performance Impact

This provides **O(1) lookups** instead of **O(n)**, which is especially beneficial for large job sets with many cross-job dependencies.

## Testing

- All existing tests updated and passing
- No behavioral changes, only performance improvement
- Validated with `make ci` (fmt, lint, tests all pass)

Fixes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)