### PR TITLE
fix: use explicit SUN for @weekly shortcut instead of numeric 7

### DIFF
--- a/src/core/schedule.rs
+++ b/src/core/schedule.rs
@@ -105,7 +105,7 @@ impl Schedule {
         match expression.to_lowercase().as_str() {
             "@yearly" | "@annually" => Self::parse_cron("0 0 1 1 *"),
             "@monthly" => Self::parse_cron("0 0 1 * *"),
-            "@weekly" => Self::parse_cron("0 0 * * 7"),
+            "@weekly" => Self::parse_cron("0 0 * * SUN"),
             "@daily" | "@midnight" => Self::parse_cron("0 0 * * *"),
             "@hourly" => Self::parse_cron("0 * * * *"),
             s if s.starts_with("@every ") => Self::parse_interval(&s[7..]),


### PR DESCRIPTION
## Summary

Changes the `@weekly` shortcut from using numeric `7` to explicit `SUN` for Sunday.

## Background

Issue #34 requested changing from `7` to `0` for Sunday to match "standard cron syntax." However, testing revealed that:

1. **POSIX standard cron**: Uses `0` for Sunday (1-6 for Mon-Sat)
2. **Vixie cron** (most Linux systems): Accepts both `0` and `7` for Sunday
3. **Quartz scheduler**: Uses `1-7` with `1` = Sunday
4. **This crate (`zslayton/cron`)**: Uses Quartz convention, requires weekdays 1-7, **does NOT accept `0`**

The cron crate explicitly rejects `0` with error: "Days of Week must be greater than or equal to 1."

## Solution

Use the explicit string `SUN` instead of numeric values because:
- ✅ Supported by the cron crate
- ✅ More readable and self-documenting
- ✅ Compatible with standard cron string syntax
- ✅ Avoids confusion about numeric conventions

## Testing

- All existing tests pass
- Verified that `SUN` is parsed correctly by the cron crate
- Confirmed `0` does NOT work (causes parse error)
- Confirmed `7` works but is less explicit

## Related

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)